### PR TITLE
feat: combined address endpoint, displayAmount, date filters, summary & eventType filter

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,8 +1,32 @@
 import express, { Request, Response, NextFunction } from "express";
 import cors from "cors";
-import { queryTransfers, queryByTxHash, getLastIndexedLedger } from "./db";
+import { queryTransfers, queryAllTransfers, queryByTxHash, querySummary, getLastIndexedLedger } from "./db";
 import { getLatestLedger } from "./rpc";
 import { getIndexerStats } from "./indexer";
+
+// ── Amount formatting ─────────────────────────────────────────────────────────
+const STROOPS = 10_000_000n;
+
+/**
+ * Convert a raw i128 decimal string (stroops) to a human-readable 7-decimal
+ * string. Uses BigInt arithmetic to avoid floating-point precision loss.
+ * e.g. "10000000000" → "1000.0000000"
+ */
+export function toDisplayAmount(amount: string): string {
+  const raw = BigInt(amount);
+  const abs = raw < 0n ? -raw : raw;
+  const integer = abs / STROOPS;
+  const remainder = abs % STROOPS;
+  const sign = raw < 0n ? "-" : "";
+  return `${sign}${integer}.${String(remainder).padStart(7, "0")}`;
+}
+
+const withDisplay = <T extends { amount: string }>(t: T) => ({
+  ...t,
+  displayAmount: toDisplayAmount(t.amount),
+});
+
+const VALID_EVENT_TYPES = new Set(["transfer", "mint", "burn", "clawback"]);
 
 export function createApp(): express.Application {
   const app = express();
@@ -10,10 +34,43 @@ export function createApp(): express.Application {
   app.use(cors());
   app.use(express.json());
 
-  // ── Helper ──────────────────────────────────────────────────────────────────
+  // ── Helpers ──────────────────────────────────────────────────────────────────
   const parseIntParam = (val: unknown, fallback: number): number => {
     const n = parseInt(String(val), 10);
     return isNaN(n) ? fallback : n;
+  };
+
+
+  /**
+   * Parse a comma-separated eventType param (e.g. "transfer,mint").
+   * Returns the array on success, sends a 400 and returns null on invalid values.
+   */
+  const parseEventTypes = (val: unknown, res: Response): string[] | null | undefined => {
+    if (val === undefined || val === "") return undefined;
+    const types = String(val).split(",").map((s) => s.trim()).filter(Boolean);
+    const invalid = types.filter((t) => !VALID_EVENT_TYPES.has(t));
+    if (invalid.length) {
+      res.status(400).json({
+        error: `Invalid eventType: "${invalid.join('", "')}". Valid values: transfer, mint, burn, clawback.`,
+      });
+      return null;
+    }
+    return types;
+  };
+
+  /**
+   * Parse an ISO 8601 date string.
+   * Returns undefined when absent, a Date when valid, null when invalid
+   * (also sends a 400 so the caller should return immediately).
+   */
+  const parseDateParam = (val: unknown, res: Response): Date | null | undefined => {
+    if (val === undefined || val === "") return undefined;
+    const d = new Date(String(val));
+    if (isNaN(d.getTime())) {
+      res.status(400).json({ error: `Invalid date: "${val}". Expected ISO 8601 (e.g. 2025-01-01T00:00:00Z).` });
+      return null;
+    }
+    return d;
   };
 
   // ── GET /status ─────────────────────────────────────────────────────────────
@@ -61,7 +118,17 @@ export function createApp(): express.Application {
     async (req: Request, res: Response, next: NextFunction) => {
       try {
         const { address } = req.params;
-        const { contractId, fromLedger, toLedger, limit, offset } = req.query;
+        const { contractId, fromLedger, toLedger, fromDate, toDate, eventType, limit, offset } = req.query;
+
+        const fromDateVal = parseDateParam(fromDate, res);
+        if (fromDateVal === null) return;
+        const toDateVal = parseDateParam(toDate, res);
+        if (toDateVal === null) return;
+        const eventTypes = parseEventTypes(eventType, res);
+        if (eventTypes === null) return;
+
+        const lim = parseIntParam(limit, 50);
+        const off = parseIntParam(offset, 0);
 
         const result = await queryTransfers({
           address,
@@ -69,11 +136,14 @@ export function createApp(): express.Application {
           contractId: contractId as string | undefined,
           fromLedger: fromLedger ? parseIntParam(fromLedger, 0) : undefined,
           toLedger: toLedger ? parseIntParam(toLedger, 0) : undefined,
-          limit: parseIntParam(limit, 50),
-          offset: parseIntParam(offset, 0),
+          fromDate: fromDateVal,
+          toDate: toDateVal,
+          eventTypes,
+          limit: lim,
+          offset: off,
         });
 
-        res.json({ ...result, limit: parseIntParam(limit, 50), offset: parseIntParam(offset, 0) });
+        res.json({ ...result, transfers: result.transfers.map(withDisplay), limit: lim, offset: off });
       } catch (err) {
         next(err);
       }
@@ -90,7 +160,17 @@ export function createApp(): express.Application {
     async (req: Request, res: Response, next: NextFunction) => {
       try {
         const { address } = req.params;
-        const { contractId, fromLedger, toLedger, limit, offset } = req.query;
+        const { contractId, fromLedger, toLedger, fromDate, toDate, eventType, limit, offset } = req.query;
+
+        const fromDateVal = parseDateParam(fromDate, res);
+        if (fromDateVal === null) return;
+        const toDateVal = parseDateParam(toDate, res);
+        if (toDateVal === null) return;
+        const eventTypes = parseEventTypes(eventType, res);
+        if (eventTypes === null) return;
+
+        const lim = parseIntParam(limit, 50);
+        const off = parseIntParam(offset, 0);
 
         const result = await queryTransfers({
           address,
@@ -98,11 +178,66 @@ export function createApp(): express.Application {
           contractId: contractId as string | undefined,
           fromLedger: fromLedger ? parseIntParam(fromLedger, 0) : undefined,
           toLedger: toLedger ? parseIntParam(toLedger, 0) : undefined,
-          limit: parseIntParam(limit, 50),
-          offset: parseIntParam(offset, 0),
+          fromDate: fromDateVal,
+          toDate: toDateVal,
+          eventTypes,
+          limit: lim,
+          offset: off,
         });
 
-        res.json({ ...result, limit: parseIntParam(limit, 50), offset: parseIntParam(offset, 0) });
+        res.json({ ...result, transfers: result.transfers.map(withDisplay), limit: lim, offset: off });
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
+
+  // ── GET /transfers/address/:address ─────────────────────────────────────────
+  /**
+   * All token transfers sent or received by `address`, merged and sorted by
+   * ledger descending. Each record includes a `direction` field
+   * ("incoming" | "outgoing").
+   *
+   * Query params:
+   *   contractId  — filter to a specific token contract
+   *   fromLedger  — inclusive lower bound
+   *   toLedger    — inclusive upper bound
+   *   limit       — page size (max 200, default 50)
+   *   offset      — pagination offset (default 0)
+   *
+   * Response:
+   *   { total, limit, offset, transfers: [{ ...fields, direction }] }
+   */
+  app.get(
+    "/transfers/address/:address",
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const { address } = req.params;
+        const { contractId, fromLedger, toLedger, fromDate, toDate, eventType, limit, offset } = req.query;
+
+        const fromDateVal = parseDateParam(fromDate, res);
+        if (fromDateVal === null) return;
+        const toDateVal = parseDateParam(toDate, res);
+        if (toDateVal === null) return;
+        const eventTypes = parseEventTypes(eventType, res);
+        if (eventTypes === null) return;
+
+        const lim = parseIntParam(limit, 50);
+        const off = parseIntParam(offset, 0);
+
+        const result = await queryAllTransfers({
+          address,
+          contractId: contractId as string | undefined,
+          fromLedger: fromLedger ? parseIntParam(fromLedger, 0) : undefined,
+          toLedger: toLedger ? parseIntParam(toLedger, 0) : undefined,
+          fromDate: fromDateVal,
+          toDate: toDateVal,
+          eventTypes,
+          limit: lim,
+          offset: off,
+        });
+
+        res.json({ ...result, transfers: result.transfers.map(withDisplay), limit: lim, offset: off });
       } catch (err) {
         next(err);
       }
@@ -121,7 +256,70 @@ export function createApp(): express.Application {
     async (req: Request, res: Response, next: NextFunction) => {
       try {
         const transfers = await queryByTxHash(req.params.txHash);
-        res.json({ transfers });
+        res.json({ transfers: transfers.map(withDisplay) });
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
+
+  // ── GET /summary/:address ────────────────────────────────────────────────────
+  /**
+   * Aggregate token stats for `address`, grouped by contractId.
+   *
+   * Query params:
+   *   contractId  — filter to a specific token contract
+   *   fromDate    — ISO 8601 inclusive lower bound on ledgerClosedAt
+   *   toDate      — ISO 8601 inclusive upper bound on ledgerClosedAt
+   *
+   * Response:
+   *   { address, window: { fromDate, toDate }, tokens: [{ contractId,
+   *     totalReceived, totalSent, netFlow,
+   *     displayTotalReceived, displayTotalSent, displayNetFlow, txCount }] }
+   */
+  app.get(
+    "/summary/:address",
+    async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        const { address } = req.params;
+        const { contractId, fromDate, toDate } = req.query;
+
+        const fromDateVal = parseDateParam(fromDate, res);
+        if (fromDateVal === null) return;
+        const toDateVal = parseDateParam(toDate, res);
+        if (toDateVal === null) return;
+
+        const rows = await querySummary({
+          address,
+          contractId: contractId as string | undefined,
+          fromDate: fromDateVal,
+          toDate: toDateVal,
+        });
+
+        const tokens = rows.map((row) => {
+          const received = BigInt(row.totalReceived);
+          const sent = BigInt(row.totalSent);
+          const net = received - sent;
+          return {
+            contractId: row.contractId,
+            totalReceived: row.totalReceived,
+            totalSent: row.totalSent,
+            netFlow: net.toString(),
+            displayTotalReceived: toDisplayAmount(row.totalReceived),
+            displayTotalSent: toDisplayAmount(row.totalSent),
+            displayNetFlow: toDisplayAmount(net.toString()),
+            txCount: Number(row.txCount),
+          };
+        });
+
+        res.json({
+          address,
+          window: {
+            fromDate: fromDateVal?.toISOString() ?? null,
+            toDate: toDateVal?.toISOString() ?? null,
+          },
+          tokens,
+        });
       } catch (err) {
         next(err);
       }

--- a/src/db.ts
+++ b/src/db.ts
@@ -74,6 +74,9 @@ export type TransferQueryParams = {
   contractId?: string;
   fromLedger?: number;
   toLedger?: number;
+  fromDate?: Date;
+  toDate?: Date;
+  eventTypes?: string[];
   limit?: number;
   offset?: number;
 };
@@ -85,6 +88,9 @@ export async function queryTransfers(params: TransferQueryParams) {
     contractId,
     fromLedger,
     toLedger,
+    fromDate,
+    toDate,
+    eventTypes,
     limit = 50,
     offset = 0,
   } = params;
@@ -92,11 +98,20 @@ export async function queryTransfers(params: TransferQueryParams) {
   const where: Prisma.TokenTransferWhereInput = {
     ...(direction === "incoming" ? { toAddress: address } : { fromAddress: address }),
     ...(contractId ? { contractId } : {}),
+    ...(eventTypes?.length ? { eventType: { in: eventTypes } } : {}),
     ...(fromLedger || toLedger
       ? {
           ledger: {
             ...(fromLedger ? { gte: fromLedger } : {}),
             ...(toLedger ? { lte: toLedger } : {}),
+          },
+        }
+      : {}),
+    ...(fromDate || toDate
+      ? {
+          ledgerClosedAt: {
+            ...(fromDate ? { gte: fromDate } : {}),
+            ...(toDate ? { lte: toDate } : {}),
           },
         }
       : {}),
@@ -120,4 +135,116 @@ export async function queryByTxHash(txHash: string) {
     where: { txHash },
     orderBy: { id: "asc" },
   });
+}
+
+// ─── Summary aggregate query ──────────────────────────────────────────────────
+export type SummaryQueryParams = {
+  address: string;
+  contractId?: string;
+  fromDate?: Date;
+  toDate?: Date;
+};
+
+type SummaryRow = {
+  contractId: string;
+  totalReceived: string; // NUMERIC cast to TEXT
+  totalSent: string;     // NUMERIC cast to TEXT
+  txCount: bigint;       // INT8 — node-postgres returns bigint columns as BigInt
+};
+
+/**
+ * Returns per-token aggregate totals for an address.
+ * Uses a raw SQL query because Prisma cannot SUM string-typed columns.
+ */
+export async function querySummary(params: SummaryQueryParams): Promise<SummaryRow[]> {
+  const { address, contractId, fromDate, toDate } = params;
+
+  const conditions: Prisma.Sql[] = [
+    Prisma.sql`("toAddress" = ${address} OR "fromAddress" = ${address})`,
+  ];
+  if (contractId) conditions.push(Prisma.sql`"contractId" = ${contractId}`);
+  if (fromDate)   conditions.push(Prisma.sql`"ledgerClosedAt" >= ${fromDate}`);
+  if (toDate)     conditions.push(Prisma.sql`"ledgerClosedAt" <= ${toDate}`);
+
+  const where = Prisma.join(conditions, " AND ");
+
+  return prisma.$queryRaw<SummaryRow[]>`
+    SELECT
+      "contractId",
+      COALESCE(SUM(CASE WHEN "toAddress"   = ${address} THEN CAST("amount" AS NUMERIC) ELSE 0 END), 0)::TEXT AS "totalReceived",
+      COALESCE(SUM(CASE WHEN "fromAddress" = ${address} THEN CAST("amount" AS NUMERIC) ELSE 0 END), 0)::TEXT AS "totalSent",
+      COUNT(*)::INT8 AS "txCount"
+    FROM "TokenTransfer"
+    WHERE ${where}
+    GROUP BY "contractId"
+    ORDER BY "contractId"
+  `;
+}
+
+// ─── Combined address query ───────────────────────────────────────────────────
+export type AllTransfersQueryParams = {
+  address: string;
+  contractId?: string;
+  fromLedger?: number;
+  toLedger?: number;
+  fromDate?: Date;
+  toDate?: Date;
+  eventTypes?: string[];
+  limit?: number;
+  offset?: number;
+};
+
+export async function queryAllTransfers(params: AllTransfersQueryParams) {
+  const {
+    address,
+    contractId,
+    fromLedger,
+    toLedger,
+    fromDate,
+    toDate,
+    eventTypes,
+    limit = 50,
+    offset = 0,
+  } = params;
+
+  const where: Prisma.TokenTransferWhereInput = {
+    OR: [{ toAddress: address }, { fromAddress: address }],
+    ...(contractId ? { contractId } : {}),
+    ...(eventTypes?.length ? { eventType: { in: eventTypes } } : {}),
+    ...(fromLedger || toLedger
+      ? {
+          ledger: {
+            ...(fromLedger ? { gte: fromLedger } : {}),
+            ...(toLedger ? { lte: toLedger } : {}),
+          },
+        }
+      : {}),
+    ...(fromDate || toDate
+      ? {
+          ledgerClosedAt: {
+            ...(fromDate ? { gte: fromDate } : {}),
+            ...(toDate ? { lte: toDate } : {}),
+          },
+        }
+      : {}),
+  };
+
+  const cap = Math.min(limit, 200);
+
+  const [total, rows] = await prisma.$transaction([
+    prisma.tokenTransfer.count({ where }),
+    prisma.tokenTransfer.findMany({
+      where,
+      orderBy: [{ ledger: "desc" }, { id: "desc" }],
+      take: cap,
+      skip: offset,
+    }),
+  ]);
+
+  const transfers = rows.map((r: { toAddress: string | null; amount: string; [key: string]: unknown }) => ({
+    ...r,
+    direction: r.toAddress === address ? "incoming" : "outgoing",
+  }));
+
+  return { total, transfers };
 }


### PR DESCRIPTION
## Summary

Implements all 5 open feature issues.

### Closes #1 — `GET /transfers/address/:address`
Added a combined incoming + outgoing endpoint. Results are merged and sorted by ledger descending. Each record includes a `direction` field (`"incoming"` | `"outgoing"`). Supports all existing query params (`contractId`, `fromLedger`, `toLedger`, `limit`, `offset`).

### Closes #2 — `displayAmount` field on all transfer responses
Added a `displayAmount` field alongside the raw `amount` on every transfer response (all endpoints including `/incoming`, `/outgoing`, `/address`, `/tx`). Uses BigInt arithmetic to divide by 10^7 and format to 7 decimal places — no floating-point precision loss. e.g. `"10000000000"` → `"1000.0000000"`.

### Closes #3 — `fromDate` / `toDate` filters
Added ISO 8601 date range filtering via `ledgerClosedAt` on `/incoming`, `/outgoing`, and `/address` endpoints. Invalid date strings return HTTP 400 with a clear error message. Works alongside existing `fromLedger` / `toLedger` params.

### Closes #4 — `GET /summary/:address`
Added aggregate stats endpoint grouped by `contractId`. Returns `totalReceived`, `totalSent`, `netFlow` (can be negative) and their `display*` variants. Uses a raw SQL query with `Prisma.sql` parameterisation since Prisma cannot `SUM` string-typed columns. Supports `fromDate`, `toDate`, and `contractId` filters.

### Closes #5 — `eventType` filter
Added `eventType` query param to `/incoming`, `/outgoing`, and `/address` endpoints. Accepts a single value or comma-separated list (e.g. `eventType=transfer,mint`). Invalid values return HTTP 400. Requests without `eventType` return all event types — no breaking change.

## Changes

- `src/db.ts` — extended `TransferQueryParams` and `AllTransfersQueryParams` with `fromDate`, `toDate`, `eventTypes`; added `querySummary` (raw SQL aggregate) and `queryAllTransfers` (combined OR query with `direction` mapping)
- `src/api.ts` — added `toDisplayAmount` helper (exported, BigInt-safe, handles negatives for netFlow), `parseEventTypes` validator, `parseDateParam` validator; wired all new params into existing and new endpoints