### PR TITLE
feat(api): add per-IP rate limiting middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,13 @@
         "@stellar/stellar-sdk": "^15.0.1",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
-        "express": "^4.18.3"
+        "express": "^4.18.3",
+        "express-rate-limit": "^8.3.2"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
+        "@types/express-rate-limit": "^5.1.3",
         "@types/node": "^20.11.24",
         "prisma": "^5.10.0",
         "ts-node-dev": "^2.0.0",
@@ -281,6 +283,16 @@
         "@types/serve-static": "^1"
       }
     },
+    "node_modules/@types/express-rate-limit": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@types/express-rate-limit/-/express-rate-limit-5.1.3.tgz",
+      "integrity": "sha512-H+TYy3K53uPU2TqPGFYaiWc2xJV6+bIFkDd/Ma2/h67Pa6ARk9kWE0p/K9OH1Okm0et9Sfm66fmXoAxsH2PHXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/express-serve-static-core": {
       "version": "4.19.8",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
@@ -314,7 +326,6 @@
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1014,6 +1025,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/feaxios": {
       "version": "0.0.23",
       "resolved": "https://registry.npmjs.org/feaxios/-/feaxios-0.0.23.tgz",
@@ -1358,6 +1387,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -1716,7 +1754,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/engines": "5.22.0"
       },
@@ -2274,7 +2311,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -17,11 +17,13 @@
     "@stellar/stellar-sdk": "^15.0.1",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
-    "express": "^4.18.3"
+    "express": "^4.18.3",
+    "express-rate-limit": "^8.3.2"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
+    "@types/express-rate-limit": "^5.1.3",
     "@types/node": "^20.11.24",
     "prisma": "^5.10.0",
     "ts-node-dev": "^2.0.0",

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,8 +1,18 @@
 import express, { Request, Response, NextFunction } from "express";
 import cors from "cors";
+import rateLimit from "express-rate-limit";
 import { queryTransfers, queryAllTransfers, queryByTxHash, querySummary, getLastIndexedLedger } from "./db";
 import { getLatestLedger } from "./rpc";
 import { getIndexerStats } from "./indexer";
+
+// ── Rate limiting ─────────────────────────────────────────────────────────────
+const limiter = rateLimit({
+  windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS ?? "60000", 10),
+  max: parseInt(process.env.RATE_LIMIT_MAX ?? "60", 10),
+  standardHeaders: true,   // Sends `RateLimit-*` headers
+  legacyHeaders: false,    // Disables `X-RateLimit-*` headers
+  message: { error: "Too many requests, please try again later." },
+});
 
 // ── Amount formatting ─────────────────────────────────────────────────────────
 const STROOPS = 10_000_000n;
@@ -33,6 +43,7 @@ export function createApp(): express.Application {
 
   app.use(cors());
   app.use(express.json());
+  app.use(limiter);
 
   // ── Helpers ──────────────────────────────────────────────────────────────────
   const parseIntParam = (val: unknown, fallback: number): number => {


### PR DESCRIPTION
## Summary

Add per-IP rate limiting to protect free endpoints from being hammered, as requested in #19.

## Implementation

Uses `express-rate-limit` middleware applied globally to all routes.

### Defaults
- **60 requests per minute** per IP
- **429** status with error message when exceeded
- Standard `RateLimit-*` headers (RFC 6585)

### Configurable via environment variables
| Variable | Default | Description |
|----------|---------|-------------|
| `RATE_LIMIT_MAX` | `60` | Max requests per window |
| `RATE_LIMIT_WINDOW_MS` | `60000` | Window duration in milliseconds |

## Acceptance criteria

- [x] 60 req/min per IP for free endpoints
- [x] 429 with Retry-After header (express-rate-limit sends this by default via `standardHeaders: true`)
- [x] Configurable via env

## Changes
- Added `express-rate-limit` dependency
- Added `limiter` middleware in `src/api.ts`
- TypeScript compiles clean (`tsc --noEmit` passes)