### PR TITLE
feat(api): add WebSocket transfer subscription endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,13 +13,15 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.18.3",
-        "express-rate-limit": "^8.3.2"
+        "express-rate-limit": "^8.3.2",
+        "ws": "^8.20.0"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "@types/express-rate-limit": "^5.1.3",
         "@types/node": "^20.11.24",
+        "@types/ws": "^8.18.1",
         "prisma": "^5.10.0",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.4.2"
@@ -326,6 +328,7 @@
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -390,6 +393,16 @@
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -984,6 +997,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -1754,6 +1768,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/engines": "5.22.0"
       },
@@ -2311,6 +2326,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2393,6 +2409,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -18,13 +18,15 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.18.3",
-    "express-rate-limit": "^8.3.2"
+    "express-rate-limit": "^8.3.2",
+    "ws": "^8.20.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/express-rate-limit": "^5.1.3",
     "@types/node": "^20.11.24",
+    "@types/ws": "^8.18.1",
     "prisma": "^5.10.0",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.4.2"

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,14 @@
+import { EventEmitter } from "events";
+import type { TransferRecord } from "./db";
+
+// Singleton emitter for real-time transfer notifications.
+// setMaxListeners(0) removes the default 10-listener cap — one listener per
+// active WebSocket subscriber is expected.
+export const transferEmitter = new EventEmitter();
+transferEmitter.setMaxListeners(0);
+
+export type TransferEvent = TransferRecord;
+
+export function emitTransfer(transfer: TransferEvent): void {
+  transferEmitter.emit("transfer:new", transfer);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,10 @@
 import "dotenv/config";
+import http from "http";
 import { execSync } from "child_process";
 import { createApp } from "./api";
 import { startIndexer } from "./indexer";
 import { prisma } from "./db";
+import { attachWebSocketServer } from "./ws";
 
 const PORT = parseInt(process.env.PORT ?? "3000", 10);
 
@@ -12,6 +14,7 @@ async function main() {
   console.log("[wraith] Running database migrations…");
   execSync("npx prisma db push --accept-data-loss", { stdio: "inherit" });
   console.log("[wraith] Database ready.");
+
   // ── Graceful shutdown ──────────────────────────────────────────────────────
   const shutdown = async (signal: string) => {
     console.log(`\n[wraith] Received ${signal} — shutting down gracefully…`);
@@ -21,10 +24,16 @@ async function main() {
   process.on("SIGINT", () => shutdown("SIGINT"));
   process.on("SIGTERM", () => shutdown("SIGTERM"));
 
-  // ── Start REST API ─────────────────────────────────────────────────────────
+  // ── Start REST API + WebSocket server ─────────────────────────────────────
   const app = createApp();
-  app.listen(PORT, () => {
+  const server = http.createServer(app);
+
+  // Attach WebSocket upgrade handler — clients connect to /subscribe/:address
+  attachWebSocketServer(server);
+
+  server.listen(PORT, () => {
     console.log(`[wraith] API listening on http://localhost:${PORT}`);
+    console.log(`[wraith] WebSocket subscriptions available at ws://localhost:${PORT}/subscribe/:address`);
   });
 
   // ── Start indexer in the background ───────────────────────────────────────

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -7,6 +7,7 @@ import {
   setLastIndexedLedger,
   pruneOldTransfers,
 } from "./db";
+import { emitTransfer } from "./events";
 
 // ─── Config ───────────────────────────────────────────────────────────────────
 const POLL_INTERVAL_MS = parseInt(process.env.POLL_INTERVAL_MS ?? "6000", 10);
@@ -70,6 +71,11 @@ async function pollOnce(
   // Persist
   const inserted = await upsertTransfers(records);
   totalIndexed += inserted;
+
+  // Broadcast each new record to WebSocket subscribers
+  if (inserted > 0) {
+    records.forEach(emitTransfer);
+  }
 
   await setLastIndexedLedger(highestLedger);
 

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -1,0 +1,62 @@
+import { WebSocketServer, WebSocket } from "ws";
+import type { IncomingMessage, Server } from "http";
+import { transferEmitter, TransferEvent } from "./events";
+import { toDisplayAmount } from "./api";
+
+// Matches /subscribe/<Stellar address>
+const SUBSCRIBE_RE = /^\/subscribe\/([A-Z0-9]+)$/;
+
+type WsPayload = TransferEvent & { displayAmount: string };
+
+function buildPayload(t: TransferEvent): WsPayload {
+  return { ...t, displayAmount: toDisplayAmount(t.amount) };
+}
+
+/**
+ * Attach a WebSocket server to an existing HTTP server.
+ *
+ * Clients connect to:  ws://host/subscribe/:address
+ *
+ * The server pushes a JSON-serialised transfer payload whenever a new
+ * transfer is indexed where `address` matches either sender or recipient.
+ * Each handler is bound to the specific socket and removed on close/error
+ * so there are no dangling listeners.
+ */
+export function attachWebSocketServer(server: Server): void {
+  const wss = new WebSocketServer({ noServer: true });
+
+  server.on("upgrade", (req: IncomingMessage, socket, head) => {
+    const url = req.url ?? "";
+    if (!SUBSCRIBE_RE.test(url)) {
+      socket.write("HTTP/1.1 404 Not Found\r\n\r\n");
+      socket.destroy();
+      return;
+    }
+
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      wss.emit("connection", ws, req);
+    });
+  });
+
+  wss.on("connection", (ws: WebSocket, req: IncomingMessage) => {
+    const match = (req.url ?? "").match(SUBSCRIBE_RE);
+    // Guaranteed by the upgrade guard, but required to satisfy TS
+    if (!match) {
+      ws.close(1008, "Invalid path");
+      return;
+    }
+    const address = match[1];
+
+    const handler = (transfer: TransferEvent) => {
+      if (ws.readyState !== WebSocket.OPEN) return;
+      if (transfer.toAddress !== address && transfer.fromAddress !== address) return;
+      ws.send(JSON.stringify(buildPayload(transfer)));
+    };
+
+    transferEmitter.on("transfer:new", handler);
+
+    const cleanup = () => transferEmitter.off("transfer:new", handler);
+    ws.on("close", cleanup);
+    ws.on("error", cleanup);
+  });
+}


### PR DESCRIPTION
## Summary

Closes #33

Real-time push notifications for token transfers via WebSocket. Clients subscribe to an address and receive a JSON payload for every new transfer that is indexed where that address appears as sender or recipient.

## What was implemented

### New files

| File | Purpose |
|---|---|
| `src/events.ts` | Singleton `EventEmitter` that publishes `transfer:new` events. `setMaxListeners(0)` prevents Node.js warnings with many concurrent subscribers. |
| `src/ws.ts` | WebSocket server using `noServer: true` + manual `upgrade` event handling. Parses address from URL, registers a per-socket handler, forwards matching events, removes handler on `close`/`error` to prevent memory leaks. |

### Modified files

| File | Change |
|---|---|
| `src/indexer.ts` | Calls `emitTransfer(record)` for every record after a successful `upsertTransfers` batch. |
| `src/index.ts` | Replaces `app.listen()` with `http.createServer(app)` so the HTTP server can handle WebSocket upgrade requests on the same port. Calls `attachWebSocketServer(server)`. |

### Endpoint

```
ws://host/subscribe/:address
```

- `:address` — any Stellar address (sender or recipient)
- Server pushes JSON on every new matching transfer; payload is identical to the REST `/transfers` response shape, including `displayAmount`
- Non-matching `/subscribe/...` paths receive an HTTP 404 and the socket is destroyed
- Connecting to an address with no incoming/outgoing traffic works fine — client simply waits until a matching event is indexed

### Payload shape (example)

```json
{
  "contractId": "CABC...",
  "eventType": "transfer",
  "fromAddress": "GBOB...",
  "toAddress": "GALICE...",
  "amount": "10000000",
  "displayAmount": "1.0000000",
  "ledger": 12345,
  "ledgerClosedAt": "2025-01-01T00:00:00.000Z",
  "txHash": "abc123",
  "eventId": "evt-001"
}
```

## How it was tested

**Build verification:**
```bash
npm run build   # → zero TypeScript errors
```

**Manual test steps:**

1. Start the server: `npm run dev`
2. Open a WebSocket client (e.g. `wscat`):
   ```bash
   wscat -c ws://localhost:3000/subscribe/GALICE...
   ```
3. Trigger an indexed transfer to/from that address
4. Observe JSON payload pushed in real-time to the client
5. Disconnect the client and confirm no memory leak (listener count stays bounded)

**Memory safety check:**
Connect and disconnect many clients rapidly — the listener count on `transferEmitter` returns to 0 after all sockets close because `transferEmitter.off(handler)` is called in both the `close` and `error` handlers.