### PR TITLE
feat(indexer): add configurable network support for mainnet ingestion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,10 +9,27 @@
 DATABASE_URL="postgresql://wraith:wraith@localhost:5432/wraith"
 DIRECT_DATABASE_URL="postgresql://wraith:wraith@localhost:5432/wraith"
 
-# ─── Stellar RPC ─────────────────────────────────────────────
-# Mainnet: https://mainnet.sorobanrpc.com
-# Testnet: https://soroban-testnet.stellar.org
-STELLAR_RPC_URL="https://soroban-testnet.stellar.org"
+# ─── Network ─────────────────────────────────────────────────
+# Set STELLAR_NETWORK to "testnet" or "mainnet".
+#   testnet → SOROBAN_RPC_URL defaults to https://soroban-testnet.stellar.org
+#   mainnet → SOROBAN_RPC_URL is required (no free public mainnet RPC)
+STELLAR_NETWORK="testnet"
+
+# ─── Soroban RPC ─────────────────────────────────────────────
+# Explicit RPC endpoint — overrides any network-based default.
+# Required when STELLAR_NETWORK=mainnet.
+# Backward-compat: STELLAR_RPC_URL is also accepted if SOROBAN_RPC_URL is unset.
+#
+# Testnet (public, free):
+#   SOROBAN_RPC_URL="https://soroban-testnet.stellar.org"
+#
+# Mainnet providers (choose one):
+#   Validation Cloud: https://mainnet.stellar.validationcloud.io/v1/<API_KEY>
+#   Ankr:             https://rpc.ankr.com/stellar_soroban/<API_KEY>
+#   Self-hosted:      https://your-own-rpc.example.com
+#
+# Leave blank when STELLAR_NETWORK=testnet to use the default testnet URL.
+SOROBAN_RPC_URL=
 
 # ─── Indexer config ──────────────────────────────────────────
 # Ledger to start indexing from (leave blank to resume from DB state)

--- a/README.md
+++ b/README.md
@@ -42,19 +42,32 @@ npx prisma generate
 cp .env.example .env
 ```
 
-Edit `.env`:
+**Testnet setup** (quick start):
 ```env
 DATABASE_URL="postgresql://wraith:wraith@localhost:5432/wraith"
-STELLAR_RPC_URL="https://soroban-testnet.stellar.org"
+STELLAR_NETWORK="testnet"
+# SOROBAN_RPC_URL is optional on testnet — the default public endpoint is used automatically
+SOROBAN_RPC_URL=
 
-# Leave blank to start from the chain tip (recommended for first run)
 START_LEDGER=
-
-# Comma-separated contract IDs to watch, or leave empty for all contracts
 CONTRACT_IDS=
-
 PORT=3000
 ```
+
+**Mainnet setup** (production):
+```env
+DATABASE_URL="postgresql://wraith:wraith@localhost:5432/wraith"
+STELLAR_NETWORK="mainnet"
+# Required on mainnet — no free public Soroban RPC exists
+SOROBAN_RPC_URL="https://mainnet.stellar.validationcloud.io/v1/<YOUR_API_KEY>"
+
+# Strongly recommended on mainnet: filter to specific contracts to reduce load
+CONTRACT_IDS="CTOKEN1...,CTOKEN2..."
+START_LEDGER=
+PORT=3000
+```
+
+> **Tip:** If you omit both `SOROBAN_RPC_URL` and `STELLAR_NETWORK`, Wraith will exit immediately with a clear error explaining what to set.
 
 ### 3. Start Postgres
 
@@ -158,22 +171,35 @@ curl "http://localhost:3000/transfers/tx/abcdef1234567890..."
 | Variable | Default | Description |
 |---|---|---|
 | `DATABASE_URL` | — | Postgres connection string (required) |
-| `STELLAR_RPC_URL` | — | Stellar RPC endpoint (required) |
-| `START_LEDGER` | *(tip)* | Ledger to start indexing from. Leave blank to resume from DB state, or start near the tip. |
-| `POLL_INTERVAL_MS` | `6000` | Polling interval (~1 ledger ≈ 6 s) |
-| `CONTRACT_IDS` | *(all)* | Comma-separated token contract IDs to watch. Empty = watch all (heavy on mainnet) |
-| `EVENTS_BATCH_SIZE` | `10000` | Max events per RPC call (RPC hard-cap is 10 000) |
+| `DIRECT_DATABASE_URL` | — | Direct (non-pooled) Postgres URL — required for Prisma migrations on Supabase |
+| `STELLAR_NETWORK` | — | `testnet` or `mainnet`. Testnet auto-configures the default RPC URL. |
+| `SOROBAN_RPC_URL` | *(see below)* | Soroban RPC endpoint. Overrides any network default. Required when `STELLAR_NETWORK=mainnet`. |
+| `STELLAR_RPC_URL` | — | Backward-compat alias for `SOROBAN_RPC_URL`. Used when `SOROBAN_RPC_URL` is unset. |
+| `START_LEDGER` | *(tip)* | Ledger to start indexing from. Leave blank to resume from DB state or start near the tip. |
+| `POLL_INTERVAL_MS` | `6000` | Polling interval in ms (~1 ledger ≈ 6 s) |
+| `CONTRACT_IDS` | *(all)* | Comma-separated token contract IDs to watch. Empty = watch all (very heavy on mainnet) |
+| `EVENTS_BATCH_SIZE` | `10000` | Max events per RPC call (Stellar RPC hard-cap is 10 000) |
+| `RETENTION_DAYS` | `30` | Delete transfers older than N days (keeps DB within free-tier limits) |
 | `PORT` | `3000` | REST API port |
 
----
+### RPC URL Resolution
 
-## RPC Endpoints
+Wraith resolves the RPC endpoint in this order and fails fast at startup if nothing is configured:
 
-| Network | URL |
+1. `SOROBAN_RPC_URL` — explicit; always wins
+2. `STELLAR_RPC_URL` — backward-compat alias
+3. `STELLAR_NETWORK=testnet` → `https://soroban-testnet.stellar.org` (free public endpoint)
+4. `STELLAR_NETWORK=mainnet` → **error**: requires explicit `SOROBAN_RPC_URL`
+5. Nothing set → **error**: clear message explaining what to configure
+
+### Mainnet RPC Providers
+
+| Provider | URL pattern |
 |---|---|
-| Mainnet | `https://mainnet.sorobanrpc.com` |
-| Testnet | `https://soroban-testnet.stellar.org` |
-| Futurenet | `https://rpc-futurenet.stellar.org` |
+| Validation Cloud | `https://mainnet.stellar.validationcloud.io/v1/<API_KEY>` |
+| Ankr | `https://rpc.ankr.com/stellar_soroban/<API_KEY>` |
+| Testnet (public) | `https://soroban-testnet.stellar.org` |
+| Futurenet (public) | `https://rpc-futurenet.stellar.org` |
 
 > **Important:** Stellar RPC retains ~7 days of event history. For longer historical coverage, use [Galexie](https://developers.stellar.org/docs/data/indexers) + the [Token Transfer Processor](https://developers.stellar.org/docs/data/indexers/build-your-own/processors/token-transfer-processor).
 

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import { fetchEventsSafe, getLatestLedger, withRetry } from "./rpc";
+import { fetchEventsSafe, getLatestLedger, withRetry, validateNetworkConfig } from "./rpc";
 import { parseEvents } from "./parser";
 import {
   upsertTransfers,
@@ -82,6 +82,9 @@ async function pollOnce(
 
 // ─── Main loop ────────────────────────────────────────────────────────────────
 export async function startIndexer(): Promise<void> {
+  // Fail fast if RPC is not configured — surfaces env errors before any DB work
+  validateNetworkConfig();
+
   console.log("[indexer] Starting Wraith indexer…");
   console.log(
     `[indexer] Watching contracts: ${CONTRACT_IDS.length > 0 ? CONTRACT_IDS.join(", ") : "ALL"}`

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -1,12 +1,57 @@
 import { rpc as RPC, xdr } from "@stellar/stellar-sdk";
 
+// ─── Network config ───────────────────────────────────────────────────────────
+const TESTNET_RPC_URL = "https://soroban-testnet.stellar.org";
+
+/**
+ * Resolve the Soroban RPC endpoint from environment variables.
+ *
+ * Resolution order:
+ *   1. SOROBAN_RPC_URL  (explicit — takes precedence)
+ *   2. STELLAR_RPC_URL  (backward-compat alias)
+ *   3. STELLAR_NETWORK=testnet  → default testnet URL
+ *   4. STELLAR_NETWORK=mainnet  → requires explicit SOROBAN_RPC_URL; no free
+ *                                  public mainnet RPC exists, so we fail fast
+ *   5. Nothing set → throws with a clear configuration guide
+ */
+function resolveRpcUrl(): string {
+  const explicit = process.env.SOROBAN_RPC_URL ?? process.env.STELLAR_RPC_URL;
+  if (explicit) return explicit;
+
+  const network = (process.env.STELLAR_NETWORK ?? "").toLowerCase();
+
+  if (network === "testnet") return TESTNET_RPC_URL;
+
+  if (network === "mainnet") {
+    throw new Error(
+      "[wraith] SOROBAN_RPC_URL is required when STELLAR_NETWORK=mainnet. " +
+      "There is no free public Soroban RPC for mainnet — set SOROBAN_RPC_URL " +
+      "to your provider's endpoint (e.g. Validation Cloud, Ankr, self-hosted)."
+    );
+  }
+
+  throw new Error(
+    "[wraith] RPC endpoint not configured. " +
+    "Set SOROBAN_RPC_URL to your Soroban RPC endpoint, or set STELLAR_NETWORK=testnet " +
+    "to use the default public testnet endpoint automatically."
+  );
+}
+
+/**
+ * Validate the network configuration at startup.
+ * Call this before opening DB connections so configuration errors surface
+ * immediately instead of on the first RPC call.
+ */
+export function validateNetworkConfig(): void {
+  resolveRpcUrl(); // throws with a human-readable message if misconfigured
+}
+
 // ─── RPC client singleton ─────────────────────────────────────────────────────
 let _rpc: RPC.Server | null = null;
 
 export function getRpc(): RPC.Server {
   if (!_rpc) {
-    const url = process.env.STELLAR_RPC_URL;
-    if (!url) throw new Error("STELLAR_RPC_URL is not set");
+    const url = resolveRpcUrl();
     _rpc = new RPC.Server(url, { allowHttp: url.startsWith("http://") });
   }
   return _rpc;


### PR DESCRIPTION
## Summary

Closes #38

Makes the Soroban RPC endpoint and target network fully configurable via environment variables, with a fail-fast startup check and clear error messages to guide operators.

## What was implemented

### `src/rpc.ts`

Added `resolveRpcUrl()` with a 5-step priority chain:

| Priority | Condition | Result |
|---|---|---|
| 1 | `SOROBAN_RPC_URL` set | Use it |
| 2 | `STELLAR_RPC_URL` set | Use it (backward compat) |
| 3 | `STELLAR_NETWORK=testnet` | Default to `https://soroban-testnet.stellar.org` |
| 4 | `STELLAR_NETWORK=mainnet` | **Error** — explicit `SOROBAN_RPC_URL` required |
| 5 | Nothing configured | **Error** — clear message explaining what to set |

Added `validateNetworkConfig()` — a zero-cost public function that runs the resolver and throws immediately if misconfigured.

### `src/indexer.ts`

Calls `validateNetworkConfig()` at the very start of `startIndexer()`, before any DB connection or ledger state fetch. Misconfigured RPC now surfaces as a startup error, not a silent failure minutes later.

### `.env.example`

```env
STELLAR_NETWORK="testnet"
SOROBAN_RPC_URL=          # optional on testnet, required on mainnet
```
Full inline documentation for both networks and all supported providers.

### `README.md`

- Separate testnet and mainnet `.env` examples in Quick Start
- Full env-vars reference table (new rows for `STELLAR_NETWORK`, `SOROBAN_RPC_URL`, `STELLAR_RPC_URL`, `RETENTION_DAYS`)
- RPC URL resolution order section
- Mainnet provider table (Validation Cloud, Ankr, self-hosted)

## How it was tested

**Build:**
```bash
npm run build   # → zero TypeScript errors
```

**Fail-fast scenarios (manual node verification):**

```
PASS (no config):        throws "[wraith] RPC endpoint not configured..."
PASS (mainnet no url):   throws "[wraith] SOROBAN_RPC_URL is required when STELLAR_NETWORK=mainnet..."
PASS (testnet default):  RPC.Server created — no throw
PASS (explicit URL):     no throw regardless of STELLAR_NETWORK
```

**Backward compatibility:**

Existing deployments using `STELLAR_RPC_URL=...` continue to work unchanged — the resolver checks it as a fallback when `SOROBAN_RPC_URL` is absent.

## Manual test steps (mainnet)

1. Set `STELLAR_NETWORK=mainnet` and `SOROBAN_RPC_URL=<your-endpoint>` in `.env`
2. `npm run dev` — confirm indexer starts and begins polling
3. Confirm `[indexer] Starting Wraith indexer…` appears with no RPC errors
4. Unset `SOROBAN_RPC_URL` — confirm the process exits immediately with the mainnet error message

## Manual test steps (testnet, zero config)

1. Set only `STELLAR_NETWORK=testnet` — leave `SOROBAN_RPC_URL` blank
2. `npm run dev` — confirm indexer connects to `soroban-testnet.stellar.org` automatically