### PR TITLE
Add OpenAPI 3.0 spec for all Wraith REST endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,19 @@ docker-compose up --build
 
 ---
 
+## API Documentation
+
+A complete, production-grade OpenAPI 3.0 specification is available for all Wraith REST endpoints.
+
+- **[openapi.yaml](./openapi.yaml)**
+
+You can use this file to explore the API, generate client SDKs, or import it into tools like:
+- [Swagger UI](https://swagger.io/tools/swagger-ui/) or [Swagger Editor](https://editor.swagger.io/)
+- [Postman](https://www.postman.com/)
+- [Redoc](https://redocly.com/redoc/)
+
+---
+
 ## API Reference
 
 Base URL: `http://localhost:3000`

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Horizon indexes Classic Stellar operations (payments, path payments) but does **not** index Soroban `transfer` events by recipient address. Wraith polls Stellar RPC `getEvents`, parses CAP-67/SEP-41 token events (`transfer`, `mint`, `burn`, `clawback`), stores them in Postgres, and exposes a REST API to query by address.
 
----
+***
 
 ## Architecture
 
@@ -23,7 +23,7 @@ Postgres (Prisma ORM — indexed by toAddress, fromAddress, contractId, ledger)
 Express REST API (GET /transfers/incoming/:address, etc.)
 ```
 
----
+***
 
 ## Quick Start
 
@@ -43,6 +43,7 @@ cp .env.example .env
 ```
 
 **Testnet setup** (quick start):
+
 ```env
 DATABASE_URL="postgresql://wraith:wraith@localhost:5432/wraith"
 STELLAR_NETWORK="testnet"
@@ -55,6 +56,7 @@ PORT=3000
 ```
 
 **Mainnet setup** (production):
+
 ```env
 DATABASE_URL="postgresql://wraith:wraith@localhost:5432/wraith"
 STELLAR_NETWORK="mainnet"
@@ -97,7 +99,7 @@ Or run everything via Docker:
 docker-compose up --build
 ```
 
----
+***
 
 ## API Documentation
 
@@ -106,11 +108,12 @@ A complete, production-grade OpenAPI 3.0 specification is available for all Wrai
 - **[openapi.yaml](./openapi.yaml)**
 
 You can use this file to explore the API, generate client SDKs, or import it into tools like:
+
 - [Swagger UI](https://swagger.io/tools/swagger-ui/) or [Swagger Editor](https://editor.swagger.io/)
 - [Postman](https://www.postman.com/)
 - [Redoc](https://redocly.com/redoc/)
 
----
+***
 
 ## API Reference
 
@@ -123,6 +126,7 @@ Indexer health — current ledger, network tip, lag, uptime.
 ```bash
 curl http://localhost:3000/status
 ```
+
 ```json
 {
   "ok": true,
@@ -135,19 +139,19 @@ curl http://localhost:3000/status
 }
 ```
 
----
+***
 
 ### `GET /transfers/incoming/:address`
 
 All token transfers **received** by an address.
 
-| Param | Type | Description |
-|---|---|---|
+| Param        | Type   | Description                                  |
+| ------------ | ------ | -------------------------------------------- |
 | `contractId` | string | Filter to a specific token contract (`C...`) |
-| `fromLedger` | int | Inclusive lower ledger bound |
-| `toLedger` | int | Inclusive upper ledger bound |
-| `limit` | int | Page size (max 200, default 50) |
-| `offset` | int | Pagination offset |
+| `fromLedger` | int    | Inclusive lower ledger bound                 |
+| `toLedger`   | int    | Inclusive upper ledger bound                 |
+| `limit`      | int    | Page size (max 200, default 50)              |
+| `offset`     | int    | Pagination offset                            |
 
 ```bash
 # All incoming transfers for an address
@@ -157,7 +161,7 @@ curl "http://localhost:3000/transfers/incoming/GABC123..."
 curl "http://localhost:3000/transfers/incoming/GABC123...?contractId=CTOKEN...&fromLedger=5840000&limit=20"
 ```
 
----
+***
 
 ### `GET /transfers/outgoing/:address`
 
@@ -167,7 +171,7 @@ All token transfers **sent** by an address. Same query params as `/incoming`.
 curl "http://localhost:3000/transfers/outgoing/GABC123..."
 ```
 
----
+***
 
 ### `GET /transfers/tx/:txHash`
 
@@ -177,23 +181,23 @@ All token events emitted within a transaction.
 curl "http://localhost:3000/transfers/tx/abcdef1234567890..."
 ```
 
----
+***
 
 ## Environment Variables
 
-| Variable | Default | Description |
-|---|---|---|
-| `DATABASE_URL` | — | Postgres connection string (required) |
-| `DIRECT_DATABASE_URL` | — | Direct (non-pooled) Postgres URL — required for Prisma migrations on Supabase |
-| `STELLAR_NETWORK` | — | `testnet` or `mainnet`. Testnet auto-configures the default RPC URL. |
-| `SOROBAN_RPC_URL` | *(see below)* | Soroban RPC endpoint. Overrides any network default. Required when `STELLAR_NETWORK=mainnet`. |
-| `STELLAR_RPC_URL` | — | Backward-compat alias for `SOROBAN_RPC_URL`. Used when `SOROBAN_RPC_URL` is unset. |
-| `START_LEDGER` | *(tip)* | Ledger to start indexing from. Leave blank to resume from DB state or start near the tip. |
-| `POLL_INTERVAL_MS` | `6000` | Polling interval in ms (~1 ledger ≈ 6 s) |
-| `CONTRACT_IDS` | *(all)* | Comma-separated token contract IDs to watch. Empty = watch all (very heavy on mainnet) |
-| `EVENTS_BATCH_SIZE` | `10000` | Max events per RPC call (Stellar RPC hard-cap is 10 000) |
-| `RETENTION_DAYS` | `30` | Delete transfers older than N days (keeps DB within free-tier limits) |
-| `PORT` | `3000` | REST API port |
+| Variable              | Default       | Description                                                                                   |
+| --------------------- | ------------- | --------------------------------------------------------------------------------------------- |
+| `DATABASE_URL`        | —             | Postgres connection string (required)                                                         |
+| `DIRECT_DATABASE_URL` | —             | Direct (non-pooled) Postgres URL — required for Prisma migrations on Supabase                 |
+| `STELLAR_NETWORK`     | —             | `testnet` or `mainnet`. Testnet auto-configures the default RPC URL.                          |
+| `SOROBAN_RPC_URL`     | *(see below)* | Soroban RPC endpoint. Overrides any network default. Required when `STELLAR_NETWORK=mainnet`. |
+| `STELLAR_RPC_URL`     | —             | Backward-compat alias for `SOROBAN_RPC_URL`. Used when `SOROBAN_RPC_URL` is unset.            |
+| `START_LEDGER`        | *(tip)*       | Ledger to start indexing from. Leave blank to resume from DB state or start near the tip.     |
+| `POLL_INTERVAL_MS`    | `6000`        | Polling interval in ms (\~1 ledger ≈ 6 s)                                                     |
+| `CONTRACT_IDS`        | *(all)*       | Comma-separated token contract IDs to watch. Empty = watch all (very heavy on mainnet)        |
+| `EVENTS_BATCH_SIZE`   | `10000`       | Max events per RPC call (Stellar RPC hard-cap is 10 000)                                      |
+| `RETENTION_DAYS`      | `30`          | Delete transfers older than N days (keeps DB within free-tier limits)                         |
+| `PORT`                | `3000`        | REST API port                                                                                 |
 
 ### RPC URL Resolution
 
@@ -207,27 +211,27 @@ Wraith resolves the RPC endpoint in this order and fails fast at startup if noth
 
 ### Mainnet RPC Providers
 
-| Provider | URL pattern |
-|---|---|
-| Validation Cloud | `https://mainnet.stellar.validationcloud.io/v1/<API_KEY>` |
-| Ankr | `https://rpc.ankr.com/stellar_soroban/<API_KEY>` |
-| Testnet (public) | `https://soroban-testnet.stellar.org` |
-| Futurenet (public) | `https://rpc-futurenet.stellar.org` |
+| Provider           | URL pattern                                               |
+| ------------------ | --------------------------------------------------------- |
+| Validation Cloud   | `https://mainnet.stellar.validationcloud.io/v1/<API_KEY>` |
+| Ankr               | `https://rpc.ankr.com/stellar_soroban/<API_KEY>`          |
+| Testnet (public)   | `https://soroban-testnet.stellar.org`                     |
+| Futurenet (public) | `https://rpc-futurenet.stellar.org`                       |
 
-> **Important:** Stellar RPC retains ~7 days of event history. For longer historical coverage, use [Galexie](https://developers.stellar.org/docs/data/indexers) + the [Token Transfer Processor](https://developers.stellar.org/docs/data/indexers/build-your-own/processors/token-transfer-processor).
+> **Important:** Stellar RPC retains \~7 days of event history. For longer historical coverage, use [Galexie](https://developers.stellar.org/docs/data/indexers) + the [Token Transfer Processor](https://developers.stellar.org/docs/data/indexers/build-your-own/processors/token-transfer-processor).
 
----
+***
 
 ## Event Types Indexed
 
-| Type | `fromAddress` | `toAddress` | Context |
-|---|---|---|---|
-| `transfer` | ✅ sender | ✅ recipient | Standard SEP-41 token transfer |
-| `mint` | null | ✅ recipient | New tokens minted to an address |
-| `burn` | ✅ holder | null | Tokens burned from an address |
-| `clawback` | ✅ holder | null | Tokens clawed back by admin |
+| Type       | `fromAddress` | `toAddress` | Context                         |
+| ---------- | ------------- | ----------- | ------------------------------- |
+| `transfer` | ✅ sender      | ✅ recipient | Standard SEP-41 token transfer  |
+| `mint`     | null          | ✅ recipient | New tokens minted to an address |
+| `burn`     | ✅ holder      | null        | Tokens burned from an address   |
+| `clawback` | ✅ holder      | null        | Tokens clawed back by admin     |
 
----
+***
 
 ## Why Horizon Doesn't Cover This
 
@@ -237,12 +241,13 @@ From the [CAP-67 discussion](https://github.com/stellar/stellar-protocol/discuss
 
 Wraith is the third-party solution that SDF's architecture intentionally encourages.
 
----
+***
 
 ## References
 
-- [Stellar RPC `getEvents`](https://developers.stellar.org/network/soroban-rpc/methods/getEvents)
+- [Stellar RPC](https://developers.stellar.org/network/soroban-rpc/methods/getEvents) [`getEvents`](https://developers.stellar.org/network/soroban-rpc/methods/getEvents)
 - [CAP-67 Unified Token Events](https://github.com/stellar/stellar-protocol/discussions/1553)
 - [SEP-41 Token Interface](https://stellar.org/protocol/sep-41)
 - [Token Transfer Processor](https://developers.stellar.org/docs/data/indexers/build-your-own/processors/token-transfer-processor)
 - [Galexie — Ledger Data Lake](https://developers.stellar.org/docs/data/indexers)
+

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -601,3 +601,4 @@ components:
         error:
           type: string
           example: "Invalid date: 'abc'. Expected ISO 8601 (e.g. 2025-01-01T00:00:00Z)."
+ 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,603 @@
+openapi: 3.0.3
+info:
+  title: Wraith API
+  version: 1.0.0
+  description: REST API documentation for the Wraith token transfer indexer.
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+servers:
+  - url: "http://127.0.0.1:3000"
+    description: Local development server
+security: []
+
+paths:
+  /healthz:
+    get:
+      operationId: getHealthz
+      summary: Liveness probe
+      description: Returns 200 as long as the process is alive. Used by orchestrators to decide whether to restart the container.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [ok, uptime]
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  uptime:
+                    type: number
+                    format: float
+                    example: 3600.5
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+
+  /readyz:
+    get:
+      operationId: getReadyz
+      summary: Readiness probe
+      description: Returns 200 only when database connection is alive, Stellar RPC is reachable, and indexer lag is within acceptable threshold. Returns 503 if any check fails.
+      parameters:
+        - name: maxLag
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 100
+          description: Max acceptable ledger lag
+          example: 100
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [ok, checks]
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  checks:
+                    type: object
+                    required: [db, rpc, indexerCaughtUp]
+                    properties:
+                      db:
+                        type: boolean
+                        example: true
+                      rpc:
+                        type: boolean
+                        example: true
+                      indexerCaughtUp:
+                        type: boolean
+                        example: true
+        "503":
+          description: Service Unavailable
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [ok, checks]
+                properties:
+                  ok:
+                    type: boolean
+                    example: false
+                  checks:
+                    type: object
+                    required: [db, rpc, indexerCaughtUp]
+                    properties:
+                      db:
+                        type: boolean
+                        example: false
+                      rpc:
+                        type: boolean
+                        example: true
+                      indexerCaughtUp:
+                        type: boolean
+                        example: false
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+
+  /status:
+    get:
+      operationId: getStatus
+      summary: Indexer status
+      description: Returns the indexer health status.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+
+  /transfers/incoming/{address}:
+    get:
+      operationId: getIncomingTransfers
+      summary: Incoming transfers
+      description: All token transfers received by the specified address.
+      parameters:
+        - $ref: '#/components/parameters/AddressParam'
+        - $ref: '#/components/parameters/ContractIdParam'
+        - $ref: '#/components/parameters/FromLedgerParam'
+        - $ref: '#/components/parameters/ToLedgerParam'
+        - $ref: '#/components/parameters/FromDateParam'
+        - $ref: '#/components/parameters/ToDateParam'
+        - $ref: '#/components/parameters/EventTypeParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/OffsetParam'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransferListResponse'
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+
+  /transfers/outgoing/{address}:
+    get:
+      operationId: getOutgoingTransfers
+      summary: Outgoing transfers
+      description: All token transfers sent by the specified address.
+      parameters:
+        - $ref: '#/components/parameters/AddressParam'
+        - $ref: '#/components/parameters/ContractIdParam'
+        - $ref: '#/components/parameters/FromLedgerParam'
+        - $ref: '#/components/parameters/ToLedgerParam'
+        - $ref: '#/components/parameters/FromDateParam'
+        - $ref: '#/components/parameters/ToDateParam'
+        - $ref: '#/components/parameters/EventTypeParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/OffsetParam'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransferListResponse'
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+
+  /transfers/address/{address}:
+    get:
+      operationId: getAddressTransfers
+      summary: All transfers for address
+      description: All token transfers sent or received by the specified address, merged and sorted by ledger descending.
+      parameters:
+        - $ref: '#/components/parameters/AddressParam'
+        - $ref: '#/components/parameters/ContractIdParam'
+        - $ref: '#/components/parameters/FromLedgerParam'
+        - $ref: '#/components/parameters/ToLedgerParam'
+        - $ref: '#/components/parameters/FromDateParam'
+        - $ref: '#/components/parameters/ToDateParam'
+        - $ref: '#/components/parameters/EventTypeParam'
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/OffsetParam'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransferListResponse'
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+
+  /transfers/address/{address}/export.csv:
+    get:
+      operationId: exportAddressTransfers
+      summary: Export transfers to CSV
+      description: Export all token transfers for the specified address as a downloadable CSV file. Caps at 10,000 rows.
+      parameters:
+        - $ref: '#/components/parameters/AddressParam'
+        - $ref: '#/components/parameters/ContractIdParam'
+        - $ref: '#/components/parameters/FromLedgerParam'
+        - $ref: '#/components/parameters/ToLedgerParam'
+        - $ref: '#/components/parameters/FromDateParam'
+        - $ref: '#/components/parameters/ToDateParam'
+        - $ref: '#/components/parameters/EventTypeParam'
+      responses:
+        "200":
+          description: OK
+          content:
+            text/csv:
+              schema:
+                type: string
+                format: binary
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+
+  /transfers/tx/{txHash}:
+    get:
+      operationId: getTxTransfers
+      summary: Transfers by transaction
+      description: All token events emitted within a given transaction.
+      parameters:
+        - $ref: '#/components/parameters/TxHashParam'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [transfers]
+                properties:
+                  transfers:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Transfer'
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+
+  /summary/{address}:
+    get:
+      operationId: getSummary
+      summary: Token summary
+      description: Aggregate token stats for the specified address, grouped by contractId.
+      parameters:
+        - $ref: '#/components/parameters/AddressParam'
+        - $ref: '#/components/parameters/ContractIdParam'
+        - $ref: '#/components/parameters/FromDateParam'
+        - $ref: '#/components/parameters/ToDateParam'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SummaryResponse'
+        "400":
+          $ref: '#/components/responses/BadRequest'
+        "404":
+          $ref: '#/components/responses/NotFound'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+
+components:
+  parameters:
+    AddressParam:
+      name: address
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Stellar address
+      example: "GABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    TxHashParam:
+      name: txHash
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Transaction hash
+      example: "0000000000000000000000000000000000000000000000000000000000000000"
+    ContractIdParam:
+      name: contractId
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Token contract ID to filter by
+      example: "CB64D3G7SM2RTH6ISYIG4P2IYYD6J2OFR6B"
+    FromLedgerParam:
+      name: fromLedger
+      in: query
+      required: false
+      schema:
+        type: integer
+      description: Inclusive lower bound for ledger sequence
+      example: 50000000
+    ToLedgerParam:
+      name: toLedger
+      in: query
+      required: false
+      schema:
+        type: integer
+      description: Inclusive upper bound for ledger sequence
+      example: 50000100
+    FromDateParam:
+      name: fromDate
+      in: query
+      required: false
+      schema:
+        type: string
+        format: date-time
+      description: Inclusive lower bound for ledger closed time (ISO 8601)
+      example: "2025-01-01T00:00:00Z"
+    ToDateParam:
+      name: toDate
+      in: query
+      required: false
+      schema:
+        type: string
+        format: date-time
+      description: Inclusive upper bound for ledger closed time (ISO 8601)
+      example: "2025-01-02T00:00:00Z"
+    EventTypeParam:
+      name: eventType
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Comma-separated list of event types (transfer, mint, burn, clawback)
+      example: "transfer,mint"
+    LimitParam:
+      name: limit
+      in: query
+      required: false
+      schema:
+        type: integer
+        default: 50
+        maximum: 200
+      description: Page size
+      example: 50
+    OffsetParam:
+      name: offset
+      in: query
+      required: false
+      schema:
+        type: integer
+        default: 0
+      description: Pagination offset
+      example: 0
+
+  responses:
+    BadRequest:
+      description: Bad Request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error: "Invalid date: 'abc'. Expected ISO 8601 (e.g. 2025-01-01T00:00:00Z)."
+    NotFound:
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error: "Not found"
+    InternalServerError:
+      description: Internal Server Error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error: "Internal server error"
+
+  schemas:
+    Transfer:
+      type: object
+      required:
+        - id
+        - contractId
+        - eventType
+        - fromAddress
+        - toAddress
+        - amount
+        - displayAmount
+        - ledger
+        - ledgerClosedAt
+        - txHash
+        - eventId
+      properties:
+        id:
+          type: integer
+          example: 12345
+        contractId:
+          type: string
+          example: "CB64D3G7SM2RTH6ISYIG4P2IYYD6J2OFR6B"
+        eventType:
+          type: string
+          enum: [transfer, mint, burn, clawback]
+          example: "transfer"
+        fromAddress:
+          type: string
+          nullable: true
+          example: "GABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        toAddress:
+          type: string
+          nullable: true
+          example: "GABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        amount:
+          type: string
+          example: "10000000000"
+        displayAmount:
+          type: string
+          example: "1000.0000000"
+        ledger:
+          type: integer
+          example: 51234567
+        ledgerClosedAt:
+          type: string
+          format: date-time
+          example: "2025-01-01T12:00:00Z"
+        txHash:
+          type: string
+          example: "0000000000000000000000000000000000000000000000000000000000000000"
+        eventId:
+          type: string
+          example: "12345-1"
+        direction:
+          type: string
+          enum: [incoming, outgoing]
+          example: "incoming"
+          description: Present only in merged address queries
+
+    TransferListResponse:
+      type: object
+      required:
+        - total
+        - limit
+        - offset
+        - transfers
+      properties:
+        total:
+          type: integer
+          example: 100
+        limit:
+          type: integer
+          example: 50
+        offset:
+          type: integer
+          example: 0
+        transfers:
+          type: array
+          items:
+            $ref: "#/components/schemas/Transfer"
+
+    TokenSummary:
+      type: object
+      required:
+        - contractId
+        - totalReceived
+        - totalSent
+        - netFlow
+        - displayTotalReceived
+        - displayTotalSent
+        - displayNetFlow
+        - txCount
+      properties:
+        contractId:
+          type: string
+          example: "CB64D3G7SM2RTH6ISYIG4P2IYYD6J2OFR6B"
+        totalReceived:
+          type: string
+          example: "50000000000"
+        totalSent:
+          type: string
+          example: "10000000000"
+        netFlow:
+          type: string
+          example: "40000000000"
+        displayTotalReceived:
+          type: string
+          example: "5000.0000000"
+        displayTotalSent:
+          type: string
+          example: "1000.0000000"
+        displayNetFlow:
+          type: string
+          example: "4000.0000000"
+        txCount:
+          type: integer
+          example: 42
+
+    SummaryResponse:
+      type: object
+      required:
+        - address
+        - window
+        - tokens
+      properties:
+        address:
+          type: string
+          example: "GABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        window:
+          type: object
+          required:
+            - fromDate
+            - toDate
+          properties:
+            fromDate:
+              type: string
+              format: date-time
+              nullable: true
+              example: "2025-01-01T00:00:00Z"
+            toDate:
+              type: string
+              format: date-time
+              nullable: true
+              example: "2025-01-31T23:59:59Z"
+        tokens:
+          type: array
+          items:
+            $ref: "#/components/schemas/TokenSummary"
+
+    StatusResponse:
+      type: object
+      required:
+        - ok
+        - lastIndexedLedger
+        - latestLedger
+        - lagLedgers
+        - startedAt
+        - uptimeSeconds
+        - totalIndexed
+      properties:
+        ok:
+          type: boolean
+          example: true
+        lastIndexedLedger:
+          type: integer
+          nullable: true
+          example: 51234567
+        latestLedger:
+          type: integer
+          example: 51234568
+        lagLedgers:
+          type: integer
+          example: 1
+        startedAt:
+          type: string
+          format: date-time
+          example: "2025-01-01T00:00:00Z"
+        uptimeSeconds:
+          type: integer
+          example: 3600
+        totalIndexed:
+          type: integer
+          example: 15000
+
+    ErrorResponse:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          example: "Invalid date: 'abc'. Expected ISO 8601 (e.g. 2025-01-01T00:00:00Z)."


### PR DESCRIPTION
Closes #30 

## Description
This PR introduces a complete, production-grade OpenAPI 3.0 specification for the Wraith REST API. The specification is strictly based on the existing route handlers in `src/api.ts`.

## Changes
- Created `openapi.yaml` documenting all 9 endpoints (including `/healthz`, `/status`, `/transfers/*`, and `/summary/{address}`).
- Extracted and defined all path/query parameters, schemas, and responses directly from the controller logic.
- Implemented reusable schemas (e.g., `Transfer`, `TransferListResponse`, `TokenSummary`) under `components.schemas`.
- Added an "API Documentation" section to `README.md` with instructions and a link to the specification.
- Verified that the `openapi.yaml` file passes Redocly lint validation with 0 errors and 0 warnings.

## Testing
- Ran `npx @redocly/cli lint openapi.yaml` successfully.