### PR TITLE
ci: add Dependabot weekly npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - "Miracle656"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to automate weekly npm dependency updates
- Assigns PRs to `Miracle656` with a limit of 5 open PRs at a time

## Test plan
- [ ] Verify `.github/dependabot.yml` is present and valid YAML
- [ ] Confirm weekly schedule is configured
- [ ] Confirm PRs will be assigned to `Miracle656`

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)